### PR TITLE
Minor fixes to the pointer masking spec

### DIFF
--- a/zjpm/background.adoc
+++ b/zjpm/background.adoc
@@ -112,7 +112,7 @@ Pointer masking applies to all explicit memory accesses. Currently, in the Base 
 
 * **Base Instruction Set**: LB, LH, LW, LBU, LHU, LWU, LD, SB, SH, SW, SD.
 * **Atomics**: All instructions in RV32A and RV64A.
-* **Floating Point**: FLW, FLD, LFQ, FSW, FSD, FSQ.
+* **Floating Point**: FLW, FLD, FLQ, FSW, FSD, FSQ.
 * **Compressed**: All instructions mapping to any of the above, and C.LWSP, C.LDSP, C.LQSP, C.FLWSP, C.FLDSP, C.SWSP, C.SDSP, C.SQSP, C.FSWSP, C.FSDSP.
 * **Memory Management**: FENCE, FENCE.I (if the currently unused address fields become enabled in the future), SFENCE.\*, HFENCE.*, SINVAL.\*, HINVAL.*.
 * **Hypervisor Extension**: HLV, HLVX, HSV

--- a/zjpm/background.adoc
+++ b/zjpm/background.adoc
@@ -115,7 +115,7 @@ Pointer masking applies to all explicit memory accesses. Currently, in the Base 
 * **Floating Point**: FLW, FLD, FLQ, FSW, FSD, FSQ.
 * **Compressed**: All instructions mapping to any of the above, and C.LWSP, C.LDSP, C.LQSP, C.FLWSP, C.FLDSP, C.SWSP, C.SDSP, C.SQSP, C.FSWSP, C.FSDSP.
 * **Memory Management**: FENCE, FENCE.I (if the currently unused address fields become enabled in the future), SFENCE.\*, HFENCE.*, SINVAL.\*, HINVAL.*.
-* **Hypervisor Extension**: HLV, HLVX, HSV
+* **Hypervisor Extension**: HLV.\*, HLVX.\*, HSV.\*
 * **Cache Management Operations**: All instructions in Zicbom, Zicbop and Zicboz.
 * **Vector Extension**: All vector load and store instructions in the ratified RVV 1.0 spec.
 

--- a/zjpm/instructions.adoc
+++ b/zjpm/instructions.adoc
@@ -46,7 +46,7 @@ Since pointer masking applies to the effective address only and does not affect 
 
 === Interaction with Two-Stage Address Translation
 
-Guest physical addresses (GPAs) are 2 bits wider than the corresponding virtual address translation modes, resulting in additional address translation schemes Sv32x4, Sv39x4, Sv48x4 and Sv57x4 for translating guest physical addresses to supervisor physical addresses. When running with virtualization in VS/VU mode with `vsatp.MODE` = Bare, this means that those two bits may be subject to pointer masking, depending on `hgatp.MODE` and `senvcfg.PMM`. If `vsatp.MODE` != BARE, this issue does *not* apply.
+Guest physical addresses (GPAs) are 2 bits wider than the corresponding virtual address translation modes, resulting in additional address translation schemes Sv32x4, Sv39x4, Sv48x4 and Sv57x4 for translating guest physical addresses to supervisor physical addresses. When running with virtualization in VS/VU mode with `vsatp.MODE` = Bare, this means that those two bits may be subject to pointer masking, depending on `hgatp.MODE` and `henvcfg.PMM`. If `vsatp.MODE` != BARE, this issue does *not* apply.
 
 [NOTE]
 ====


### PR DESCRIPTION
I'm not 100% sure about the third one, but I think this matches with the earlier description of `henvcfg.PMM`; please take a look before merging.